### PR TITLE
make `npm start` point to `rwb serve`

### DIFF
--- a/lib/Workflows.js
+++ b/lib/Workflows.js
@@ -64,6 +64,9 @@ var Workflows = {
     packageJsonData.react.routes = packageJsonData.react.routes || './routes.js';
     packageJsonData.react.rwb = myPackageJson.version;
 
+    packageJsonData.scripts = packageJsonData.scripts || {};
+    packageJsonData.scripts.start = 'rwb serve';
+
     fs.writeFileSync(packageJson, JSON.stringify(packageJsonData, undefined, 2), {encoding: 'utf8'});
 
     ncp(path.join(__dirname, 'template'), process.cwd(), function(err) {


### PR DESCRIPTION
This makes sure your `rwb` project can be started like any other Node project.
