### PR TITLE
WIP: enable SSL

### DIFF
--- a/lib/Workflows.js
+++ b/lib/Workflows.js
@@ -15,10 +15,9 @@ var temp = require('temp');
 var webpack = require('webpack');
 var webpackRequire = require('webpack-require');
 
-// TODO: SSL?
 // TODO: document these
 var PORT = process.env.RWB_PORT || 3000;
-var PUBLIC_URL = process.env.RWB_PUBLIC_URL || 'http://localhost:' + PORT + '/';
+var PUBLIC_URL = process.env.RWB_PUBLIC_URL || 'https://localhost:' + PORT + '/';
 var SKIP_SOURCEMAPS = !!JSON.parse(process.env.RWB_SKIP_SOURCEMAPS || 'false');
 var DOM_NODE_ID = process.env.RWB_DOM_NODE_ID || '.react-root';
 
@@ -177,6 +176,11 @@ var Workflows = {
         publicPath: config.output.publicPath,
         hot: true,
         historyApiFallback: true,
+        https: { // enable HTTPS, default to webpack-dev-server's key/cert/ca
+          key: false,
+          cert: false,
+          ca: false,
+        },
         headers: {
           'Access-Control-Allow-Origin': '*',
         },


### PR DESCRIPTION
Should this be configurable, and if so, how configurable? Simple yes or no? Specify your own key/cert/ca?

I just did a bit of digging on generating valid SSL certificates for `localhost` with Let’s Encrypt. Apparently a public CA is not allowed to generate certs for localhost (see: https://github.com/letsencrypt/boulder/issues/137#issuecomment-112236543).

This leaves us with a few options I can think of (ordered from least painful to most):
1. EDIT: I just discovered [localtest.me](http://readme.localtest.me). Any requests to `*.localtest.me` over HTTP or HTTPS point to `127.0.0.1`. I think this might be a pretty great option.
2. Use something like [ngrok](https://ngrok.com) and set `RWB_PUBLIC_URL` to the ngrok URL.
3. Use `webpack-dev-server`’s built-in self-signed certificate. Anyone who’s already accepted the cert doesn’t have to stress about it again.
4. Specify an rwb-specific self-signed certificate.
5. Point `local.rwb.somedomain.com` to localhost, fork `webpack-dev-server` and add support for properly signed SSL certificates with something like [letsencrypt-express](https://github.com/Daplie/letsencrypt-express). Sounds messy, requires editing `/etc/hosts`. I don’t know enough about this stuff to even know if that would work, but I do know computers do weird things when `localhost` is involved.

Maybe there’s something else I haven’t thought of? (entirely likely)
