### PR TITLE
updates routes.js template for latest react-router

### DIFF
--- a/lib/template/routes.js
+++ b/lib/template/routes.js
@@ -4,4 +4,4 @@ var MyComponent = require('./MyComponent');
 var React = require('react');
 var {Route} = require('react-router');
 
-module.exports = <Route handler={MyComponent} />;
+module.exports = <Route path="/" component={MyComponent} />;


### PR DESCRIPTION
The default `routes.js` template is broken (with the latest react-router?) ... this fixes it.
