### PR TITLE
don't run node_modules through webpack loaders

### DIFF
--- a/lib/Workflows.js
+++ b/lib/Workflows.js
@@ -148,6 +148,7 @@ var Workflows = {
               test: /\.js$/,
               loader: require.resolve('react-hot-loader') + '!' + require.resolve('babel-loader') + '?stage=1',
               include: packageRoot,
+              exclude: path.join(packageRoot, 'node_modules'),
             },
             {
               test: /\.json$/,


### PR DESCRIPTION
I had an issue where a comment in some file within a dependency broke my bundle.  Telling webpack not to run `<packageRoot>/node_modules` through hot-loader or babel fixed it, and seems like most folks do this (though my experience is still somewhat limited).
