### PR TITLE
update README to specify using the published npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The great developer experience of `rwb` is a trojan horse designed to increase a
 ## How to develop
 
 ```
-npm install -g git+https://github.com/petehunt/rwb
+npm install -g rwb
 mkdir myapp
 cd myapp
 npm init


### PR DESCRIPTION
This specifies using the published `npm` package in `README.md`; instead of the `github` version which  appears problematic ATM; #26 

![image](https://cloud.githubusercontent.com/assets/773345/15611687/65f068a0-23e0-11e6-870c-165bab756069.png)
